### PR TITLE
Fix zoom factor bug in UrlFractals

### DIFF
--- a/UrlFractals.js
+++ b/UrlFractals.js
@@ -23,7 +23,11 @@
         x: ((hash & 0xFFFF) / 0xFFFF) * 1 - 0.5, // Adjust range for x-offset (-0.5 to 0.5)
         y: ((hash >> 16 & 0xFFFF) / 0xFFFF) * 1 - 0.5 // Adjust range for y-offset (-0.5 to 0.5)
     };
-    const zoom = 0.1 + (((hash >> 32) & 0xFFFF) / 0xFFFF) * 0.1; // Adjust zoom computation to increase minimum zoom level
+    // Bitwise operations in JavaScript operate on 32bit signed integers. The
+    // previous code attempted to use the upper 32 bits of `hash` which always
+    // resulted in zero. Use the absolute value of the hash instead so each URL
+    // generates a different zoom factor.
+    const zoom = 0.1 + (Math.abs(hash % 0x7fffffff) / 0x7fffffff) * 0.1;
 
     function drawFractal(canvas, color, iterations) {
         const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- adjust zoom computation in `UrlFractals.js` so each URL generates a different fractal zoom level

## Testing
- `node --check UrlFractals.js`

------
https://chatgpt.com/codex/tasks/task_e_685b842adf28833388662905d1d4e832