### PR TITLE
Fix README userscript manager names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # esoteric-firefox-userscripts
-A collection of esoteric userscripts for Firefox, mostly for personal use, but these might interest bug bounty hunters, security & vulnerability researchers, osint researchers, etc. Scripts tested with FireMonkey and the latest non-beta release of Firefox. Scripts are likely compatible with your favorite userscript manager like TamperMonkey and ViolentMonkey. 
+A collection of esoteric userscripts for Firefox, mostly for personal use, but these might interest bug bounty hunters, security & vulnerability researchers, osint researchers, etc. Scripts tested with FireMonkey and the latest non-beta release of Firefox. Scripts are likely compatible with your favorite userscript manager like Tampermonkey and Violentmonkey. 
 
 
 # Disclaimer


### PR DESCRIPTION
## Summary
- fix the capitalization of Tampermonkey and Violentmonkey in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b85ab89c88333b9cbb2677938a8ba